### PR TITLE
Fix dependency conflict in github actions test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,4 @@ langchain-community==0.2.9
 langchain-core==0.1.35
 tiktoken==0.5.2
 # Ensure starlette is up to date (will be managed by fastapi)
-starlette>=0.47.2
 


### PR DESCRIPTION
Remove explicit `starlette` version from `requirements.txt` to resolve dependency conflict with `fastapi`.

The `fastapi==0.109.1` package requires `starlette` versions between `0.35.0` and `0.36.0`. The explicit `starlette>=0.47.2` in `requirements.txt` caused a dependency conflict during installation in GitHub Actions, leading to an `ERROR: ResolutionImpossible`. Removing this constraint allows pip to install a compatible version.

---

[Open in Web](https://cursor.com/agents?id=bc-8af42933-ea10-4510-a550-dcc9e40be13a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8af42933-ea10-4510-a550-dcc9e40be13a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)